### PR TITLE
Usable server and client

### DIFF
--- a/Build/premake5.lua
+++ b/Build/premake5.lua
@@ -91,12 +91,19 @@ workspace ("DestroyerOfWorlds")
                 "../Code/core/include/",
                 "../Code/network/include/",
                 "../Code/protocol/include/",
+                "../ThirdParty/cryptopp/",
             }
 
             files
             {
                 "../Code/network/include/**.h",
                 "../Code/network/src/**.cpp",
+            }
+
+            links
+            {
+                "Core",
+                "cryptopp"
             }
 
             filter { "architecture:*86" }

--- a/Code/core/include/Buffer.h
+++ b/Code/core/include/Buffer.h
@@ -35,6 +35,7 @@ public:
 
         size_t GetBytePosition() const;
         size_t GetBitPosition() const;
+        size_t GetSize() const;
 
     protected:
 

--- a/Code/core/src/Buffer.cpp
+++ b/Code/core/src/Buffer.cpp
@@ -126,6 +126,11 @@ size_t Buffer::Cursor::GetBytePosition() const
     return m_bitPosition / 8;
 }
 
+size_t Buffer::Cursor::GetSize() const
+{
+    return m_pBuffer->GetSize();
+}
+
 Buffer::Reader::Reader(Buffer* apBuffer)
     : Buffer::Cursor(apBuffer)
 {

--- a/Code/network/include/Client.h
+++ b/Code/network/include/Client.h
@@ -49,7 +49,7 @@ protected:
 
         if (m_connection.IsNegotiating())
         {
-            if (m_connection.ProcessPacket(reader))
+            if (!m_connection.ProcessPacket(reader).HasError())
             {
                 if (m_connection.IsConnected())
                 {
@@ -63,9 +63,15 @@ protected:
         }
         else if (m_connection.IsConnected())
         {
-            if (m_connection.ProcessPacket(reader))
+            auto headerType = m_connection.ProcessPacket(reader);
+
+            if (headerType.HasError())
             {
-                // FIXME check that it's the payload type...
+                // TODO error handling
+                return false;
+            }
+            else if (headerType.GetResult() == Connection::Header::kPayload)
+            {
                 return OnPacketReceived(reader);
             }
         }

--- a/Code/network/include/Client.h
+++ b/Code/network/include/Client.h
@@ -2,117 +2,21 @@
 
 #include "Socket.h"
 #include "ConnectionManager.h"
-#include "StackAllocator.h"
-
-// TODO migrate code to cpp
 
 class Client : public AllocatorCompatible
     , public Connection::ICommunication
 {
 public:
-    Client(const Endpoint& acRemoteEndpoint)
-        : m_connection(*this, acRemoteEndpoint)
-        , m_socket(acRemoteEndpoint.GetType(), false)
-    {
-        m_socket.Bind();
-    }
+    Client(const Endpoint& acRemoteEndpoint);
 
-    void Disconnect() noexcept
-    {
-        if (!m_connection.GetState() == Connection::kNone)
-        {
-            m_connection.Disconnect();
-        }
-    }
+    void Disconnect() noexcept;
+    bool Send(const Endpoint& acRemoteEndpoint, Buffer aBuffer) noexcept override;
+    bool SendPayload(uint8_t *apData, size_t aLength) noexcept;
 
-    bool Send(const Endpoint& acRemoteEndpoint, Buffer aBuffer) noexcept override
-    {
-        Socket::Packet packet{ acRemoteEndpoint, std::move(aBuffer) };
-        return m_socket.Send(packet);
-    }
-
-    bool SendPayload(uint8_t *apData, size_t aLength) noexcept
-    {
-        if (!m_connection.IsConnected())
-        {
-            return false;
-        }
-
-        // FIXME memory is allocated (and freed) for every packet sent
-        Buffer *pBuffer = GetAllocator()->New<Buffer>(aLength + 8); // Assuming 8 header bytes
-        Buffer::Writer writer(pBuffer);
-        m_connection.WriteHeader(writer, Connection::Header::kPayload);
-        writer.WriteBytes(apData, aLength);
-        bool sent = Send(m_connection.GetRemoteEndpoint(), *pBuffer);
-        GetAllocator()->Delete<Buffer>(pBuffer);
-        return sent;
-    }
-
-    uint32_t Update(const uint64_t aElapsedMilliSeconds) noexcept
-    {
-        uint32_t processedPackets = 0;
-        Outcome<Socket::Packet, Socket::Error> result = m_socket.Receive();
-
-        while (!result.HasError())
-        {
-            // Route packet to a connection
-            if (ProcessPacket(result.GetResult()))
-                ++processedPackets;
-
-            result = m_socket.Receive();
-        }
-
-        if (m_connection.Update(aElapsedMilliSeconds) == Connection::kNone)
-        {
-            OnDisconnected(m_connection.GetRemoteEndpoint());
-        }
-
-        // TODO error handling
-        return processedPackets;
-    }
+    uint32_t Update(const uint64_t aElapsedMilliSeconds) noexcept;
 
 protected:
-    bool ProcessPacket(Socket::Packet& aPacket) noexcept
-    {
-        Buffer::Reader reader(&aPacket.Payload);
-
-        switch (m_connection.GetState())
-        {
-        case Connection::kNone:
-            break;
-        case Connection::kNegociating:
-        {
-            if (!m_connection.ProcessPacket(reader).HasError())
-            {
-                if (m_connection.IsConnected())
-                {
-                    OnConnected(m_connection.GetRemoteEndpoint());
-                }
-
-                return true;
-            }
-        }
-        break;
-
-        case Connection::kConnected:
-        {
-            auto headerType = m_connection.ProcessPacket(reader);
-
-            // TODO error handling
-            if (!headerType.HasError() && headerType.GetResult() == Connection::Header::kPayload)
-            {
-                return OnPacketReceived(aPacket.Remote, reader);
-            }
-        }
-        break;
-
-        default:
-            // TODO log about new unhandled connection state
-            return false;
-        }
-
-        return false;
-    }
+    bool ProcessPacket(Socket::Packet& aPacket) noexcept;
 
     virtual bool OnPacketReceived(const Endpoint& acRemoteEndpoint, Buffer::Reader &acBufferReader) noexcept = 0;
     virtual bool OnConnected(const Endpoint& acRemoteEndpoint) noexcept = 0;

--- a/Code/network/include/Client.h
+++ b/Code/network/include/Client.h
@@ -18,7 +18,7 @@ public:
 protected:
     bool ProcessPacket(Socket::Packet& aPacket) noexcept;
 
-    virtual bool OnPacketReceived(const Endpoint& acRemoteEndpoint, Buffer::Reader &aBufferReader) noexcept = 0;
+    virtual bool OnMessageReceived(const Endpoint& acRemoteEndpoint, const Message& acMessage) noexcept = 0;
     virtual bool OnConnected(const Endpoint& acRemoteEndpoint) noexcept = 0;
     virtual bool OnDisconnected(const Endpoint& acRemoteEndpoint) noexcept = 0;
     

--- a/Code/network/include/Client.h
+++ b/Code/network/include/Client.h
@@ -13,12 +13,12 @@ public:
     bool Send(const Endpoint& acRemoteEndpoint, Buffer aBuffer) noexcept override;
     bool SendPayload(uint8_t *apData, size_t aLength) noexcept;
 
-    uint32_t Update(const uint64_t aElapsedMilliSeconds) noexcept;
+    uint32_t Update(const uint64_t acElapsedMilliSeconds) noexcept;
 
 protected:
     bool ProcessPacket(Socket::Packet& aPacket) noexcept;
 
-    virtual bool OnPacketReceived(const Endpoint& acRemoteEndpoint, Buffer::Reader &acBufferReader) noexcept = 0;
+    virtual bool OnPacketReceived(const Endpoint& acRemoteEndpoint, Buffer::Reader &aBufferReader) noexcept = 0;
     virtual bool OnConnected(const Endpoint& acRemoteEndpoint) noexcept = 0;
     virtual bool OnDisconnected(const Endpoint& acRemoteEndpoint) noexcept = 0;
     

--- a/Code/network/include/Client.h
+++ b/Code/network/include/Client.h
@@ -13,7 +13,7 @@ public:
     bool Send(const Endpoint& acRemoteEndpoint, Buffer aBuffer) noexcept override;
     bool SendPayload(uint8_t *apData, size_t aLength) noexcept;
 
-    uint32_t Update(const uint64_t acElapsedMilliSeconds) noexcept;
+    uint32_t Update(uint64_t aElapsedMilliSeconds) noexcept;
 
 protected:
     bool ProcessPacket(Socket::Packet& aPacket) noexcept;

--- a/Code/network/include/Client.h
+++ b/Code/network/include/Client.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "Socket.h"
+#include "ConnectionManager.h"
+
+// TODO migrate code to cpp
+
+class Client : public AllocatorCompatible
+    , public Connection::ICommunication
+{
+public:
+    Client(const Endpoint& acRemoteEndpoint)
+        : m_connection(*this, acRemoteEndpoint)
+        , m_socket(acRemoteEndpoint.GetType(), false)
+    {
+        m_socket.Bind();
+    }
+
+    bool Send(const Endpoint& acRemoteEndpoint, Buffer aBuffer) noexcept override
+    {
+        Socket::Packet packet{ acRemoteEndpoint, std::move(aBuffer) };
+        return m_socket.Send(packet);
+    }
+
+    uint32_t Update(const uint64_t aElapsedMilliSeconds) noexcept
+    {
+        uint32_t processedPackets = 0;
+        Outcome<Socket::Packet, Socket::Error> result = m_socket.Receive();
+
+        while (!result.HasError())
+        {
+            // Route packet to a connection
+            if (ProcessPacket(result.GetResult()))
+                ++processedPackets;
+
+            result = m_socket.Receive();
+        }
+
+        m_connection.Update(aElapsedMilliSeconds);
+
+        // TODO error handling
+        return processedPackets;
+    }
+
+protected:
+    bool ProcessPacket(Socket::Packet& aPacket) noexcept
+    {
+        Buffer::Reader reader(&aPacket.Payload);
+
+        if (m_connection.IsNegotiating())
+        {
+            if (m_connection.ProcessPacket(reader))
+            {
+                if (m_connection.IsConnected())
+                {
+                    // OnClientConnected
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+        else if (m_connection.IsConnected())
+        {
+            if (m_connection.ProcessPacket(reader))
+            {
+                // FIXME check that it's the payload type...
+                return OnPacketReceived(reader);
+            }
+        }
+
+        return false;
+    }
+
+    bool OnPacketReceived(const Buffer::Reader &acBufferReader) noexcept
+    {
+        return true;
+    }
+
+private:
+    Connection m_connection;
+    Socket m_socket;
+};

--- a/Code/network/include/Connection.h
+++ b/Code/network/include/Connection.h
@@ -16,6 +16,7 @@ public:
         {
             kNegotiation,
             kConnection,
+            kDisconnect,
             kPayload,
             kCount
         };
@@ -40,10 +41,10 @@ public:
         kBadPacketType,
         kTooLarge,
         kUnknownChannel,
-        kUnknownPacket,
         kPayloadRequired,
         kBadKey,
-        kBadChallenge
+        kBadChallenge,
+        kDeadConnection
     };
 
     struct ICommunication
@@ -67,13 +68,15 @@ public:
     State GetState() const;
     const Endpoint& GetRemoteEndpoint() const;
 
-    void Update(uint64_t aElapsedMilliseconds);
+    uint64_t Update(uint64_t aElapsedMilliseconds);
+    void Disconnect();
 
     void WriteHeader(Buffer::Writer& aWriter, const uint64_t acHeaderType);
 
 protected:
 
     Outcome<Header, HeaderErrors> ProcessHeader(Buffer::Reader& aReader);
+    Outcome<uint64_t, Connection::HeaderErrors> ProcessDisconnection(Buffer::Reader & aReader);
     Outcome<uint64_t, Connection::HeaderErrors> ProcessNegociation(Buffer::Reader & aReader);
     Outcome<uint64_t, Connection::HeaderErrors> ProcessConfirmation(Buffer::Reader & aReader);
 

--- a/Code/network/include/Connection.h
+++ b/Code/network/include/Connection.h
@@ -5,9 +5,10 @@
 #include "Endpoint.h"
 #include "DHChachaFilter.h"
 #include "Socket.h"
+#include "MessageReceiver.h"
 
 class Socket;
-class Connection
+class Connection: public MessageReceiver
 {
 public:
 
@@ -75,6 +76,8 @@ public:
 
     void WriteHeader(Buffer::Writer& aWriter, HeaderType aHeaderType);
 
+    uint32_t GetNextMessageSeq();
+
 protected:
 
     Outcome<Header, HeaderErrors> ProcessHeader(Buffer::Reader& aReader);
@@ -100,5 +103,6 @@ private:
     DHChachaFilter m_filter;
     uint32_t m_challengeCode;
     uint32_t m_remoteCode;
+    uint32_t m_messageSeq;
     bool m_isServer;
 };

--- a/Code/network/include/Connection.h
+++ b/Code/network/include/Connection.h
@@ -52,7 +52,7 @@ public:
         virtual bool Send(const Endpoint& acRemote, Buffer aBuffer) = 0;
     };
 
-    Connection(ICommunication& aCommunicationInterface, const Endpoint& acRemoteEndpoint, const bool acNeedsAuthentication=false);
+    Connection(ICommunication& aCommunicationInterface, const Endpoint& acRemoteEndpoint, const bool acIsServer=false);
     Connection(const Connection& acRhs) = delete;
     Connection(Connection&& aRhs) noexcept;
 

--- a/Code/network/include/Connection.h
+++ b/Code/network/include/Connection.h
@@ -69,8 +69,11 @@ public:
 
     void Update(uint64_t aElapsedMilliseconds);
 
+    void WriteHeader(Buffer::Writer& aWriter, const uint64_t acHeaderType);
+
 protected:
 
+    Outcome<Header, HeaderErrors> ProcessHeader(Buffer::Reader& aReader);
     Outcome<uint64_t, Connection::HeaderErrors> ProcessNegociation(Buffer::Reader & aReader);
     Outcome<uint64_t, Connection::HeaderErrors> ProcessConfirmation(Buffer::Reader & aReader);
 
@@ -79,9 +82,6 @@ protected:
 
     bool WriteChallenge(Buffer::Writer& aWriter, uint32_t aCode);
     bool ReadChallenge(Buffer::Reader& aReader, uint32_t &aCode);
-
-    Outcome<Header, HeaderErrors> ProcessHeader(Buffer::Reader& aReader);
-    void WriteHeader(Buffer::Writer & aWriter, const uint64_t acHeaderType);
 
 private:
 

--- a/Code/network/include/Connection.h
+++ b/Code/network/include/Connection.h
@@ -39,7 +39,11 @@ public:
         kBadVersion,
         kBadPacketType,
         kTooLarge,
-        kUnknownChannel
+        kUnknownChannel,
+        kUnknownPacket,
+        kPayloadRequired,
+        kBadKey,
+        kBadChallenge
     };
 
     struct ICommunication
@@ -56,7 +60,7 @@ public:
     Connection& operator=(Connection&& aRhs) noexcept;
     Connection& operator=(const Connection& aRhs) = delete;
 
-    bool ProcessPacket(Buffer::Reader & aReader);
+    Outcome<uint64_t, Connection::HeaderErrors> ProcessPacket(Buffer::Reader & aReader);
     bool IsNegotiating() const;
     bool IsConnected() const;
 
@@ -67,8 +71,8 @@ public:
 
 protected:
 
-    bool ProcessNegociation(Buffer::Reader & aReader);
-    bool ProcessConfirmation(Buffer::Reader & aReader);
+    Outcome<uint64_t, Connection::HeaderErrors> ProcessNegociation(Buffer::Reader & aReader);
+    Outcome<uint64_t, Connection::HeaderErrors> ProcessConfirmation(Buffer::Reader & aReader);
 
     void SendNegotiation();
     void SendConfirmation();

--- a/Code/network/include/Connection.h
+++ b/Code/network/include/Connection.h
@@ -4,6 +4,7 @@
 #include "Outcome.h"
 #include "Endpoint.h"
 #include "DHChachaFilter.h"
+#include "Socket.h"
 
 class Socket;
 class Connection
@@ -43,7 +44,6 @@ public:
         kBadPacketType,
         kTooLarge,
         kUnknownChannel,
-        kPayloadRequired,
         kBadKey,
         kBadChallenge,
         kDeadConnection
@@ -89,6 +89,9 @@ protected:
     bool ReadChallenge(Buffer::Reader& aReader, uint32_t &aCode);
 
 private:
+
+    static constexpr size_t MaxNegotiationSize = 200;
+    static constexpr size_t ClientPadding = Socket::MaxPacketSize - MaxNegotiationSize;
 
     ICommunication& m_communication;
     State m_state;

--- a/Code/network/include/Connection.h
+++ b/Code/network/include/Connection.h
@@ -77,7 +77,7 @@ protected:
     void SendNegotiation();
     void SendConfirmation();
 
-    bool WriteChallenge(Buffer::Writer& aWriter);
+    bool WriteChallenge(Buffer::Writer& aWriter, uint32_t aCode);
     bool ReadChallenge(Buffer::Reader& aReader, uint32_t &aCode);
 
     Outcome<Header, HeaderErrors> ProcessHeader(Buffer::Reader& aReader);
@@ -92,4 +92,5 @@ private:
     DHChachaFilter m_filter;
     bool m_isServer;
     uint32_t m_challengeCode;
+    uint32_t m_remoteCode;
 };

--- a/Code/network/include/Connection.h
+++ b/Code/network/include/Connection.h
@@ -10,6 +10,8 @@ class Connection
 {
 public:
 
+    typedef uint64_t HeaderType;
+
     struct Header
     {
         enum
@@ -23,7 +25,7 @@ public:
 
         char Signature[2];
         uint64_t Version;
-        uint64_t Type;
+        HeaderType Type;
         uint64_t Length;
     };
 
@@ -52,7 +54,7 @@ public:
         virtual bool Send(const Endpoint& acRemote, Buffer aBuffer) = 0;
     };
 
-    Connection(ICommunication& aCommunicationInterface, const Endpoint& acRemoteEndpoint, const bool acIsServer=false);
+    Connection(ICommunication& aCommunicationInterface, const Endpoint& acRemoteEndpoint, bool aIsServer=false);
     Connection(const Connection& acRhs) = delete;
     Connection(Connection&& aRhs) noexcept;
 
@@ -61,24 +63,24 @@ public:
     Connection& operator=(Connection&& aRhs) noexcept;
     Connection& operator=(const Connection& aRhs) = delete;
 
-    Outcome<uint64_t, Connection::HeaderErrors> ProcessPacket(Buffer::Reader & aReader);
+    Outcome<HeaderType, Connection::HeaderErrors> ProcessPacket(Buffer::Reader & aReader);
     bool IsNegotiating() const;
     bool IsConnected() const;
 
     State GetState() const;
     const Endpoint& GetRemoteEndpoint() const;
 
-    uint64_t Update(uint64_t aElapsedMilliseconds);
+    State Update(uint64_t aElapsedMilliseconds);
     void Disconnect();
 
-    void WriteHeader(Buffer::Writer& aWriter, const uint64_t acHeaderType);
+    void WriteHeader(Buffer::Writer& aWriter, HeaderType aHeaderType);
 
 protected:
 
     Outcome<Header, HeaderErrors> ProcessHeader(Buffer::Reader& aReader);
-    Outcome<uint64_t, Connection::HeaderErrors> ProcessDisconnection(Buffer::Reader & aReader);
-    Outcome<uint64_t, Connection::HeaderErrors> ProcessNegociation(Buffer::Reader & aReader);
-    Outcome<uint64_t, Connection::HeaderErrors> ProcessConfirmation(Buffer::Reader & aReader);
+    Outcome<HeaderType, Connection::HeaderErrors> ProcessDisconnection(Buffer::Reader & aReader);
+    Outcome<HeaderType, Connection::HeaderErrors> ProcessNegociation(Buffer::Reader & aReader);
+    Outcome<HeaderType, Connection::HeaderErrors> ProcessConfirmation(Buffer::Reader & aReader);
 
     void SendNegotiation();
     void SendConfirmation();
@@ -93,7 +95,7 @@ private:
     uint64_t m_timeSinceLastEvent;
     Endpoint m_remoteEndpoint;
     DHChachaFilter m_filter;
-    bool m_isServer;
     uint32_t m_challengeCode;
     uint32_t m_remoteCode;
+    bool m_isServer;
 };

--- a/Code/network/include/ConnectionManager.h
+++ b/Code/network/include/ConnectionManager.h
@@ -17,7 +17,7 @@ public:
 
     bool IsFull() const;
 
-    void Update(uint64_t aElapsedMilliSeconds);
+    void Update(uint64_t aElapsedMilliSeconds, std::function<bool(const Endpoint&)> aDisconnectedCallback = nullptr);
 
 private:
 

--- a/Code/network/include/Server.h
+++ b/Code/network/include/Server.h
@@ -16,12 +16,11 @@ public:
     uint16_t GetPort() const noexcept;
 
     bool Send(const Endpoint& acRemoteEndpoint, Buffer aBuffer) noexcept override;
+    bool SendPayload(const Endpoint& acRemoteEndpoint, uint8_t *apData, size_t aLength) noexcept;
 
 protected:
-    bool OnPacketReceived(const Buffer::Reader &acBufferReader) noexcept
-    {
-        return true;
-    };
+    virtual bool OnPacketReceived(const Endpoint& acRemoteEndpoint, Buffer::Reader &acBufferReader) noexcept = 0;
+    virtual bool OnClientConnected(const Endpoint& acRemoteEndpoint) noexcept = 0;
     bool ProcessPacket(Socket::Packet& aPacket) noexcept;
 
 private:

--- a/Code/network/include/Server.h
+++ b/Code/network/include/Server.h
@@ -15,12 +15,14 @@ public:
     uint32_t Update(uint64_t aElapsedMilliSeconds) noexcept;
     uint16_t GetPort() const noexcept;
 
+    void Disconnect(const Endpoint& acRemoteEndpoint) noexcept;
     bool Send(const Endpoint& acRemoteEndpoint, Buffer aBuffer) noexcept override;
     bool SendPayload(const Endpoint& acRemoteEndpoint, uint8_t *apData, size_t aLength) noexcept;
 
 protected:
     virtual bool OnPacketReceived(const Endpoint& acRemoteEndpoint, Buffer::Reader &acBufferReader) noexcept = 0;
     virtual bool OnClientConnected(const Endpoint& acRemoteEndpoint) noexcept = 0;
+    virtual bool OnClientDisconnected(const Endpoint& acRemoteEndpoint) noexcept = 0;
     bool ProcessPacket(Socket::Packet& aPacket) noexcept;
 
 private:

--- a/Code/network/include/Server.h
+++ b/Code/network/include/Server.h
@@ -20,7 +20,7 @@ public:
     bool SendPayload(const Endpoint& acRemoteEndpoint, uint8_t *apData, size_t aLength) noexcept;
 
 protected:
-    virtual bool OnPacketReceived(const Endpoint& acRemoteEndpoint, Buffer::Reader &aBufferReader) noexcept = 0;
+    virtual bool OnMessageReceived(const Endpoint& acRemoteEndpoint, const Message& acMessage) noexcept = 0;
     virtual bool OnClientConnected(const Endpoint& acRemoteEndpoint) noexcept = 0;
     virtual bool OnClientDisconnected(const Endpoint& acRemoteEndpoint) noexcept = 0;
     bool ProcessPacket(Socket::Packet& aPacket) noexcept;

--- a/Code/network/include/Server.h
+++ b/Code/network/include/Server.h
@@ -11,8 +11,8 @@ public:
     Server();
     ~Server();
 
-    bool Start(uint16_t aPort) noexcept;
-    uint32_t Update(uint64_t aElapsedMilliSeconds) noexcept;
+    bool Start(const uint16_t acPort) noexcept;
+    uint32_t Update(const uint64_t acElapsedMilliSeconds) noexcept;
     uint16_t GetPort() const noexcept;
 
     void Disconnect(const Endpoint& acRemoteEndpoint) noexcept;
@@ -20,7 +20,7 @@ public:
     bool SendPayload(const Endpoint& acRemoteEndpoint, uint8_t *apData, size_t aLength) noexcept;
 
 protected:
-    virtual bool OnPacketReceived(const Endpoint& acRemoteEndpoint, Buffer::Reader &acBufferReader) noexcept = 0;
+    virtual bool OnPacketReceived(const Endpoint& acRemoteEndpoint, Buffer::Reader &aBufferReader) noexcept = 0;
     virtual bool OnClientConnected(const Endpoint& acRemoteEndpoint) noexcept = 0;
     virtual bool OnClientDisconnected(const Endpoint& acRemoteEndpoint) noexcept = 0;
     bool ProcessPacket(Socket::Packet& aPacket) noexcept;

--- a/Code/network/include/Server.h
+++ b/Code/network/include/Server.h
@@ -11,19 +11,22 @@ public:
     Server();
     ~Server();
 
-    bool Start(uint16_t aPort);
-    uint32_t Update(uint64_t aElapsedMilliSeconds);
-    uint16_t GetPort() const;
+    bool Start(uint16_t aPort) noexcept;
+    uint32_t Update(uint64_t aElapsedMilliSeconds) noexcept;
+    uint16_t GetPort() const noexcept;
 
-    bool Send(const Endpoint& acRemoteEndpoint, Buffer aBuffer) override;
+    bool Send(const Endpoint& acRemoteEndpoint, Buffer aBuffer) noexcept override;
 
 protected:
-
-    bool ProcessPacket(Socket::Packet& aPacket);
+    bool OnPacketReceived(const Buffer::Reader &acBufferReader) noexcept
+    {
+        return true;
+    };
+    bool ProcessPacket(Socket::Packet& aPacket) noexcept;
 
 private:
 
-    uint32_t Work();
+    uint32_t Work() noexcept;
 
     Socket m_v4Listener, m_v6Listener;
     ConnectionManager m_connectionManager;

--- a/Code/network/include/Server.h
+++ b/Code/network/include/Server.h
@@ -11,8 +11,8 @@ public:
     Server();
     ~Server();
 
-    bool Start(const uint16_t acPort) noexcept;
-    uint32_t Update(const uint64_t acElapsedMilliSeconds) noexcept;
+    bool Start(uint16_t aPort) noexcept;
+    uint32_t Update(uint64_t aElapsedMilliSeconds) noexcept;
     uint16_t GetPort() const noexcept;
 
     void Disconnect(const Endpoint& acRemoteEndpoint) noexcept;

--- a/Code/network/include/Socket.h
+++ b/Code/network/include/Socket.h
@@ -9,6 +9,8 @@ class Socket
 {
 public:
 
+    static constexpr size_t MaxPacketSize = 1200;
+
     enum Error
     {
         kInvalidSocket,
@@ -39,8 +41,6 @@ protected:
 private:
 
     friend class Selector;
-
-    static constexpr size_t MaxPacketSize = 1200;
 
     Socket_t m_sock;
     uint16_t m_port;

--- a/Code/network/src/Client.cpp
+++ b/Code/network/src/Client.cpp
@@ -1,0 +1,104 @@
+#include "Client.h"
+
+Client::Client(const Endpoint& acRemoteEndpoint)
+    : m_connection(*this, acRemoteEndpoint)
+    , m_socket(acRemoteEndpoint.GetType(), false)
+{
+    m_socket.Bind();
+}
+
+void Client::Disconnect() noexcept
+{
+    if (!m_connection.GetState() == Connection::kNone)
+    {
+        m_connection.Disconnect();
+    }
+}
+
+bool Client::Send(const Endpoint& acRemoteEndpoint, Buffer aBuffer) noexcept
+{
+    Socket::Packet packet{ acRemoteEndpoint, std::move(aBuffer) };
+    return m_socket.Send(packet);
+}
+
+bool Client::SendPayload(uint8_t *apData, size_t aLength) noexcept
+{
+    if (!m_connection.IsConnected())
+    {
+        return false;
+    }
+
+    // FIXME memory is allocated (and freed) for every packet sent
+    Buffer *pBuffer = GetAllocator()->New<Buffer>(aLength + 8); // Assuming 8 header bytes
+    Buffer::Writer writer(pBuffer);
+    m_connection.WriteHeader(writer, Connection::Header::kPayload);
+    writer.WriteBytes(apData, aLength);
+    bool sent = Send(m_connection.GetRemoteEndpoint(), *pBuffer);
+    GetAllocator()->Delete<Buffer>(pBuffer);
+    return sent;
+}
+
+uint32_t Client::Update(const uint64_t aElapsedMilliSeconds) noexcept
+{
+    uint32_t processedPackets = 0;
+    Outcome<Socket::Packet, Socket::Error> result = m_socket.Receive();
+
+    while (!result.HasError())
+    {
+        // Route packet to a connection
+        if (ProcessPacket(result.GetResult()))
+            ++processedPackets;
+
+        result = m_socket.Receive();
+    }
+
+    if (m_connection.Update(aElapsedMilliSeconds) == Connection::kNone)
+    {
+        OnDisconnected(m_connection.GetRemoteEndpoint());
+    }
+
+    // TODO error handling
+    return processedPackets;
+}
+
+bool Client::ProcessPacket(Socket::Packet& aPacket) noexcept
+{
+    Buffer::Reader reader(&aPacket.Payload);
+
+    switch (m_connection.GetState())
+    {
+    case Connection::kNone:
+        break;
+    case Connection::kNegociating:
+    {
+        if (!m_connection.ProcessPacket(reader).HasError())
+        {
+            if (m_connection.IsConnected())
+            {
+                OnConnected(m_connection.GetRemoteEndpoint());
+            }
+
+            return true;
+        }
+    }
+    break;
+
+    case Connection::kConnected:
+    {
+        auto headerType = m_connection.ProcessPacket(reader);
+
+        // TODO error handling
+        if (!headerType.HasError() && headerType.GetResult() == Connection::Header::kPayload)
+        {
+            return OnPacketReceived(aPacket.Remote, reader);
+        }
+    }
+    break;
+
+    default:
+        // TODO log about new unhandled connection state
+        return false;
+    }
+
+    return false;
+}

--- a/Code/network/src/Client.cpp
+++ b/Code/network/src/Client.cpp
@@ -88,7 +88,8 @@ bool Client::ProcessPacket(Socket::Packet& aPacket) noexcept
         auto headerType = m_connection.ProcessPacket(reader);
 
         // TODO error handling
-        if (!headerType.HasError() && headerType.GetResult() == Connection::Header::kPayload)
+        if (!headerType.HasError()
+            && (headerType.GetResult() == Connection::Header::kPayload || headerType.GetResult() == Connection::Header::kDisconnect))
         {
             return OnPacketReceived(aPacket.Remote, reader);
         }

--- a/Code/network/src/Client.cpp
+++ b/Code/network/src/Client.cpp
@@ -38,7 +38,7 @@ bool Client::SendPayload(uint8_t *apData, size_t aLength) noexcept
     return sent;
 }
 
-uint32_t Client::Update(const uint64_t aElapsedMilliSeconds) noexcept
+uint32_t Client::Update(const uint64_t acElapsedMilliSeconds) noexcept
 {
     uint32_t processedPackets = 0;
     Outcome<Socket::Packet, Socket::Error> result = m_socket.Receive();
@@ -52,7 +52,7 @@ uint32_t Client::Update(const uint64_t aElapsedMilliSeconds) noexcept
         result = m_socket.Receive();
     }
 
-    if (m_connection.Update(aElapsedMilliSeconds) == Connection::kNone)
+    if (m_connection.Update(acElapsedMilliSeconds) == Connection::kNone)
     {
         OnDisconnected(m_connection.GetRemoteEndpoint());
     }

--- a/Code/network/src/Client.cpp
+++ b/Code/network/src/Client.cpp
@@ -38,7 +38,7 @@ bool Client::SendPayload(uint8_t *apData, size_t aLength) noexcept
     return sent;
 }
 
-uint32_t Client::Update(const uint64_t acElapsedMilliSeconds) noexcept
+uint32_t Client::Update(uint64_t aElapsedMilliSeconds) noexcept
 {
     uint32_t processedPackets = 0;
     Outcome<Socket::Packet, Socket::Error> result = m_socket.Receive();
@@ -52,7 +52,7 @@ uint32_t Client::Update(const uint64_t acElapsedMilliSeconds) noexcept
         result = m_socket.Receive();
     }
 
-    if (m_connection.Update(acElapsedMilliSeconds) == Connection::kNone)
+    if (m_connection.Update(aElapsedMilliSeconds) == Connection::kNone)
     {
         OnDisconnected(m_connection.GetRemoteEndpoint());
     }

--- a/Code/network/src/Connection.cpp
+++ b/Code/network/src/Connection.cpp
@@ -199,9 +199,9 @@ const Endpoint& Connection::GetRemoteEndpoint() const
     return m_remoteEndpoint;
 }
 
-uint64_t Connection::Update(uint64_t aElapsedMilliseconds)
+uint64_t Connection::Update(const uint64_t acElapsedMilliseconds)
 {
-    m_timeSinceLastEvent += aElapsedMilliseconds;
+    m_timeSinceLastEvent += acElapsedMilliseconds;
 
     // Connection is considered timed out if no data is received in 15s (TODO: make this configurable)
     if (m_timeSinceLastEvent > 15 * 1000)

--- a/Code/network/src/Connection.cpp
+++ b/Code/network/src/Connection.cpp
@@ -243,7 +243,7 @@ void Connection::WriteHeader(Buffer::Writer& aWriter, const uint64_t acHeaderTyp
 
 void Connection::Disconnect()
 {
-    StackAllocator<32> allocator;
+    StackAllocator<256> allocator;
     auto* pBuffer = allocator.New<Buffer>(16);
 
     Buffer::Writer writer(pBuffer);

--- a/Code/network/src/Connection.cpp
+++ b/Code/network/src/Connection.cpp
@@ -18,12 +18,22 @@ static NullCommunicationInterface s_dummyInterface;
 
 static const char* s_headerSignature = "MG";
 
-Connection::Connection(ICommunication& aCommunicationInterface, const Endpoint& acRemoteEndpoint)
+Connection::Connection(ICommunication& aCommunicationInterface, const Endpoint& acRemoteEndpoint, const bool acIsServer)
     : m_communication{ aCommunicationInterface }
     , m_state{kNegociating}
     , m_timeSinceLastEvent{0}
     , m_remoteEndpoint{acRemoteEndpoint}
+    , m_isServer{acIsServer}
 {
+    if (acIsServer)
+    {
+        // TODO secure random
+        m_challengeCode = 24;
+    }
+    else
+    {
+        m_challengeCode = 0;
+    }
 
 }
 
@@ -32,10 +42,13 @@ Connection::Connection(Connection&& aRhs) noexcept
     , m_state{std::move(aRhs.m_state)}
     , m_timeSinceLastEvent{std::move(aRhs.m_timeSinceLastEvent)}
     , m_remoteEndpoint{std::move(aRhs.m_remoteEndpoint)}
+    , m_isServer{aRhs.m_isServer}
+    , m_challengeCode{aRhs.m_challengeCode}
 {
     aRhs.m_communication = s_dummyInterface;
     aRhs.m_state = kNone;
     aRhs.m_timeSinceLastEvent = 0;
+    aRhs.m_challengeCode = 0;
 }
 
 Connection::~Connection()
@@ -48,39 +61,87 @@ Connection& Connection::operator=(Connection&& aRhs) noexcept
     m_state = aRhs.m_state;
     m_timeSinceLastEvent = aRhs.m_timeSinceLastEvent;
     m_remoteEndpoint = std::move(aRhs.m_remoteEndpoint);
+    m_isServer = aRhs.m_isServer;
+    m_challengeCode = aRhs.m_challengeCode;
 
     aRhs.m_communication = s_dummyInterface;
     aRhs.m_state = kNone;
     aRhs.m_timeSinceLastEvent = 0;
+    aRhs.m_challengeCode = 0;
 
     return *this;
 }
 
-bool Connection::ProcessPacket(Buffer* apBuffer)
-{
-    Buffer::Reader reader(apBuffer);
-    
-    auto header = ProcessHeader(reader);
+bool Connection::ProcessPacket(Buffer::Reader& aReader)
+{   
+    auto header = ProcessHeader(aReader);
     if (header.HasError())
+    {
         return false;
+    }
 
-    m_timeSinceLastEvent = 0;
+    switch (header.GetResult().Type)
+    {
+    case Header::kNegotiation:
+        return ProcessNegociation(aReader);
+    case Header::kConnection:
+        return ProcessConfirmation(aReader);
+    case Header::kPayload:
+        m_timeSinceLastEvent = 0;
+        break;
+    default:
+        return false;
+    }
 
     return true;
 }
 
-bool Connection::ProcessNegociation(Buffer* apBuffer)
+bool Connection::ProcessNegociation(Buffer::Reader& aReader)
 {
-    Buffer::Reader reader(apBuffer);
-
-    auto header = ProcessHeader(reader);
-    if (header.HasError())
+    if (!m_filter.ReceiveConnect(&aReader))
+    {
+        // Drop connection if key is not accepted
+        m_state = Connection::kNone;
         return false;
+    }
 
-    if (m_filter.ReceiveConnect(&reader))
+    if (m_isServer)
+    {
+        // TODO enforce payload size
+    }
+    else if (ReadChallenge(aReader, m_challengeCode))
+    {
+        // We (client) assume to be connected and send back the challenge code
         m_state = kConnected;
+        SendConfirmation();
+    }
 
     return IsNegotiating() || IsConnected();
+}
+
+bool Connection::ProcessConfirmation(Buffer::Reader& aReader)
+{
+    // We are a server that needs to challenge clients
+    uint32_t otherCode = 0;
+
+    if (ReadChallenge(aReader, otherCode))
+    {
+        // FIXME is not secure for symmetric crypto, only for testing
+        if (otherCode == m_challengeCode)
+        {
+            // We got a correct challenge code back
+            m_state = kConnected;
+            return true;
+        }
+        else
+        {
+            // Wrong challenge code, drop connection
+            m_state = Connection::kNone;
+            return false;
+        }
+    }
+
+    return false;
 }
 
 bool Connection::IsNegotiating() const
@@ -128,25 +189,47 @@ void Connection::Update(uint64_t aElapsedMilliseconds)
     }
 }
 
-void Connection::SendNegotiation()
+void Connection::WriteHeader(Buffer::Writer& aWriter, const uint64_t acHeaderType)
 {
     Header header;
     header.Signature[0] = s_headerSignature[0];
     header.Signature[1] = s_headerSignature[1];
     header.Version = 1;
-    header.Type = Header::kNegotiation;
+    header.Type = acHeaderType;
     header.Length = 0;
 
+    aWriter.WriteBytes((const uint8_t*)header.Signature, 2);
+    aWriter.WriteBits(header.Version, 6);
+    aWriter.WriteBits(header.Type, 3);
+    aWriter.WriteBits(header.Length, 11);
+}
+
+void Connection::SendNegotiation()
+{
+    StackAllocator<1 << 13> allocator;
+    auto* pBuffer = allocator.New<Buffer>(m_isServer ? 200 : 1200);
+
+    Buffer::Writer writer(pBuffer);
+    WriteHeader(writer, Header::kNegotiation);
+
+    m_filter.PreConnect(&writer);
+
+    if (m_isServer)
+        WriteChallenge(writer);
+
+    m_communication.Send(m_remoteEndpoint, *pBuffer);
+
+    allocator.Delete(pBuffer);
+}
+
+void Connection::SendConfirmation()
+{
     StackAllocator<1 << 13> allocator;
     auto* pBuffer = allocator.New<Buffer>(1200);
 
     Buffer::Writer writer(pBuffer);
-    writer.WriteBytes((const uint8_t*)header.Signature, 2);
-    writer.WriteBits(header.Version, 6);
-    writer.WriteBits(header.Type, 3);
-    writer.WriteBits(header.Length, 11);
-
-    m_filter.PreConnect(&writer);
+    WriteHeader(writer, Header::kConnection);
+    WriteChallenge(writer);
 
     m_communication.Send(m_remoteEndpoint, *pBuffer);
 
@@ -178,4 +261,14 @@ Outcome<Connection::Header, Connection::HeaderErrors> Connection::ProcessHeader(
         return kTooLarge;
 
     return header;
+}
+
+bool Connection::WriteChallenge(Buffer::Writer &aWriter)
+{
+    return aWriter.WriteBytes((uint8_t *) &m_challengeCode, sizeof(m_challengeCode));
+}
+
+bool Connection::ReadChallenge(Buffer::Reader &aReader, uint32_t &aCode)
+{
+    return aReader.ReadBytes((uint8_t *) &aCode, sizeof(m_challengeCode));
 }

--- a/Code/network/src/Connection.cpp
+++ b/Code/network/src/Connection.cpp
@@ -85,12 +85,17 @@ Outcome<Connection::HeaderType, Connection::HeaderErrors> Connection::ProcessPac
     {
     case Header::kDisconnect:
         return ProcessDisconnection(aReader);
+        break;
     case Header::kNegotiation:
         if (IsNegotiating() || !m_isServer)
             return ProcessNegociation(aReader);
+
+        break;
     case Header::kConnection:
         if (m_isServer && IsNegotiating())
             return ProcessConfirmation(aReader);
+
+        break;
     case Header::kPayload:
         m_timeSinceLastEvent = 0;
         break;

--- a/Code/network/src/ConnectionManager.cpp
+++ b/Code/network/src/ConnectionManager.cpp
@@ -35,13 +35,27 @@ bool ConnectionManager::IsFull() const
     return m_connections.size() >= m_maxConnections;
 }
 
-void ConnectionManager::Update(uint64_t aElapsedMilliSeconds)
+void ConnectionManager::Update(uint64_t aElapsedMilliSeconds, std::function<bool(const Endpoint&)> aDisconnectedCallback)
 {
-    for (auto& kvp : m_connections)
-    {
-        auto& connection = kvp.second;
+    auto it = m_connections.begin();
 
-        connection.Update(aElapsedMilliSeconds);
+    while (it != m_connections.end())
+    {
+        Connection& connection = (*it).second;
+
+        if (connection.Update(aElapsedMilliSeconds) == Connection::kNone)
+        {
+            if (aDisconnectedCallback)
+            {
+                aDisconnectedCallback((*it).first);
+            }
+
+            it = m_connections.erase(it);
+        }
+        else
+        {
+            it++;
+        }
     }
 }
 

--- a/Code/network/src/Server.cpp
+++ b/Code/network/src/Server.cpp
@@ -13,19 +13,19 @@ Server::~Server()
 {
 }
 
-bool Server::Start(uint16_t aPort) noexcept
+bool Server::Start(const uint16_t acPort) noexcept
 {
-    if (m_v4Listener.Bind(aPort) == false)
+    if (m_v4Listener.Bind(acPort) == false)
     {
         return false;
     }
     return m_v6Listener.Bind(m_v4Listener.GetPort());
 }
 
-uint32_t Server::Update(uint64_t aElapsedMilliSeconds) noexcept
+uint32_t Server::Update(const uint64_t acElapsedMilliSeconds) noexcept
 {
     uint32_t nPackets = Work();
-    m_connectionManager.Update(aElapsedMilliSeconds, std::bind(&Server::OnClientDisconnected, this, std::placeholders::_1));
+    m_connectionManager.Update(acElapsedMilliSeconds, std::bind(&Server::OnClientDisconnected, this, std::placeholders::_1));
     return nPackets;
 }
 

--- a/Code/network/src/Server.cpp
+++ b/Code/network/src/Server.cpp
@@ -122,7 +122,8 @@ bool Server::ProcessPacket(Socket::Packet& aPacket) noexcept
         auto headerType = pConnection->ProcessPacket(reader);
 
         // TODO error handling
-        if (!headerType.HasError() && headerType.GetResult() == Connection::Header::kPayload)
+        if (!headerType.HasError() 
+            && (headerType.GetResult() == Connection::Header::kPayload || headerType.GetResult() == Connection::Header::kDisconnect))
         {
             return OnPacketReceived(aPacket.Remote, reader);
         }

--- a/Code/network/src/Server.cpp
+++ b/Code/network/src/Server.cpp
@@ -13,20 +13,20 @@ Server::~Server()
 {
 }
 
-bool Server::Start(const uint16_t acPort) noexcept
+bool Server::Start(uint16_t aPort) noexcept
 {
-    if (m_v4Listener.Bind(acPort) == false)
+    if (m_v4Listener.Bind(aPort) == false)
     {
         return false;
     }
     return m_v6Listener.Bind(m_v4Listener.GetPort());
 }
 
-uint32_t Server::Update(const uint64_t acElapsedMilliSeconds) noexcept
+uint32_t Server::Update(uint64_t aElapsedMilliSeconds) noexcept
 {
-    uint32_t nPackets = Work();
-    m_connectionManager.Update(acElapsedMilliSeconds, std::bind(&Server::OnClientDisconnected, this, std::placeholders::_1));
-    return nPackets;
+    uint32_t processedPackets = Work();
+    m_connectionManager.Update(aElapsedMilliSeconds, [this](const Endpoint & acRemoteEndpoint) { return OnClientDisconnected(acRemoteEndpoint); });
+    return processedPackets;
 }
 
 uint16_t Server::GetPort() const noexcept

--- a/Code/network/src/Server.cpp
+++ b/Code/network/src/Server.cpp
@@ -40,7 +40,14 @@ bool Server::Send(const Endpoint& acRemoteEndpoint, Buffer aBuffer)
     {
         Socket::Packet packet{ acRemoteEndpoint, std::move(aBuffer) };
 
-        m_v6Listener.Send(packet);
+        return m_v6Listener.Send(packet);
+    }
+
+    if (acRemoteEndpoint.IsIPv4())
+    {
+        Socket::Packet packet{ acRemoteEndpoint, std::move(aBuffer) };
+
+        return m_v4Listener.Send(packet);
     }
 
     return false;

--- a/Code/protocol/include/Message.h
+++ b/Code/protocol/include/Message.h
@@ -4,17 +4,17 @@
 
 #include "Buffer.h"
 #include "Allocator.h"
-#include "Outcome.h"
 
-class Message: public AllocatorCompatible
+class Message
 {
 public:
     static constexpr uint8_t MessageLenBits = 16;
     static constexpr size_t MaxMessageSize = (1 << MessageLenBits) - 1;
     static constexpr size_t HeaderBytes = sizeof(uint32_t) + (2*MessageLenBits + 7) / 8;
 
-    static Message& Merge(Message &aLhs, Message &aRhs) noexcept;
+    static Message& Merge(Message &aDest, Message &aSource) noexcept;
 
+    Message() noexcept;
     Message(uint32_t aSeq, uint8_t *apData, size_t aLen) noexcept;
     Message(Buffer::Reader & aReader) noexcept;
     Message(Message&& aRhs) noexcept;

--- a/Code/protocol/include/Message.h
+++ b/Code/protocol/include/Message.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Buffer.h"
+#include "Allocator.h"
+#include "Outcome.h"
+
+class Message: public AllocatorCompatible
+{
+public:
+    Message(uint32_t aSeq, uint8_t *apData, size_t aLen);
+    Message(Buffer::Reader & aReader);
+    ~Message();
+
+    uint32_t GetSeq() const noexcept;
+    Buffer::Reader GetData() noexcept;
+    bool Write(Buffer::Writer & aWriter) const noexcept;
+
+private:
+
+    uint32_t m_seq;
+    size_t m_len;
+    Buffer m_data;
+};

--- a/Code/protocol/include/Message.h
+++ b/Code/protocol/include/Message.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <list>
+
 #include "Buffer.h"
 #include "Allocator.h"
 #include "Outcome.h"
@@ -7,17 +9,55 @@
 class Message: public AllocatorCompatible
 {
 public:
-    Message(uint32_t aSeq, uint8_t *apData, size_t aLen);
-    Message(Buffer::Reader & aReader);
-    ~Message();
+    static constexpr uint8_t MessageLenBits = 16;
+    static constexpr size_t MaxMessageSize = (1 << MessageLenBits) - 1;
+    
+    enum MessageError
+    {
+        kIncompleteMessage
+    };
+
+    Message(uint32_t aSeq, uint8_t *apData, size_t aLen) noexcept;
+    Message(Buffer::Reader & aReader) noexcept;
+    Message(Message&& aRhs) noexcept;
+    Message(const Message& acRhs) noexcept;
+    ~Message() noexcept;
+
+    Message& operator=(Message&& aRhs) noexcept;
+    Message& operator=(const Message& acRhs) noexcept;
 
     uint32_t GetSeq() const noexcept;
-    Buffer::Reader GetData() noexcept;
-    bool Write(Buffer::Writer & aWriter) const noexcept;
+    size_t GetLen() const noexcept;
+    bool IsComplete() const noexcept;
+    bool IsValid() const noexcept;
+    Buffer::Reader GetData() const noexcept;
+    size_t Write(Buffer::Writer & aWriter, size_t aOffset=0) const noexcept;
 
 private:
 
-    uint32_t m_seq;
+    class Slice : public AllocatorCompatible
+    {
+    public:
+        Slice(size_t aOffset, size_t aLen) noexcept;
+        Slice(uint8_t * apData, size_t aLen) noexcept;
+        Slice(Buffer::Reader& aReader, size_t aMessageLength) noexcept;
+        Slice(Slice&& aRhs) noexcept;
+        Slice(const Slice& acRhs) noexcept;
+
+        Slice& operator=(Slice&& aRhs) noexcept;
+        Slice& operator=(const Slice& acRhs) noexcept;
+
+    private:
+        size_t m_offset;
+        size_t m_len;
+        Buffer m_data;
+        bool m_empty;
+
+        friend class Message;
+    };
+
+    std::list<Slice> m_slices;
     size_t m_len;
-    Buffer m_data;
+    uint32_t m_seq;
+
 };

--- a/Code/protocol/include/Message.h
+++ b/Code/protocol/include/Message.h
@@ -11,11 +11,9 @@ class Message: public AllocatorCompatible
 public:
     static constexpr uint8_t MessageLenBits = 16;
     static constexpr size_t MaxMessageSize = (1 << MessageLenBits) - 1;
-    
-    enum MessageError
-    {
-        kIncompleteMessage
-    };
+    static constexpr size_t HeaderBytes = sizeof(uint32_t) + (2*MessageLenBits + 7) / 8;
+
+    static Message& Merge(Message &aLhs, Message &aRhs) noexcept;
 
     Message(uint32_t aSeq, uint8_t *apData, size_t aLen) noexcept;
     Message(Buffer::Reader & aReader) noexcept;
@@ -25,6 +23,7 @@ public:
 
     Message& operator=(Message&& aRhs) noexcept;
     Message& operator=(const Message& acRhs) noexcept;
+    Message& operator+(Message& aRhs) noexcept;
 
     uint32_t GetSeq() const noexcept;
     size_t GetLen() const noexcept;
@@ -46,6 +45,8 @@ private:
 
         Slice& operator=(Slice&& aRhs) noexcept;
         Slice& operator=(const Slice& acRhs) noexcept;
+
+        size_t GetEndOffset() const noexcept;
 
     private:
         size_t m_offset;

--- a/Code/protocol/include/MessageReceiver.h
+++ b/Code/protocol/include/MessageReceiver.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Message.h"
+#include "Outcome.h"
+
+class MessageReceiver: AllocatorCompatible
+{
+public:
+
+    enum Error
+    {
+        kNoMessage,
+        kIncomplete,
+        kLengthsMismatch,
+        kOld
+    };
+
+    MessageReceiver() noexcept;
+    ~MessageReceiver() noexcept;
+
+    Outcome<Message, MessageReceiver::Error> ReadMessage(Buffer::Reader & aReader) noexcept;
+
+private:
+
+    static constexpr size_t MessageBufferSize = 256;
+    
+    std::vector<Message *> m_messageBuffer;
+};
+

--- a/Code/protocol/src/Message.cpp
+++ b/Code/protocol/src/Message.cpp
@@ -82,6 +82,12 @@ Message& Message::Merge(Message& aDest, Message& aSource) noexcept
     return aDest;
 }
 
+Message::Message() noexcept
+    : m_slices()
+    , m_len(0)
+    , m_seq(0)
+{}
+
 Message::Message(uint32_t aSeq, uint8_t *apData, size_t aLen) noexcept
     : m_slices({std::move(Message::Slice(apData, aLen))})
     , m_len(aLen)
@@ -97,7 +103,7 @@ Message::Message(Buffer::Reader& aReader) noexcept
 {
     aReader.ReadBytes((uint8_t *)&m_seq, sizeof(m_seq));
 
-    if (aReader.ReadBits(m_len, Message::MessageLenBits) && m_len <= Message::MaxMessageSize)
+    if (aReader.ReadBits(m_len, Message::MessageLenBits) && m_len < Message::MaxMessageSize)
     {
         m_slices.push_front(Slice(aReader, m_len));
         

--- a/Code/protocol/src/Message.cpp
+++ b/Code/protocol/src/Message.cpp
@@ -1,0 +1,50 @@
+#include "Message.h"
+
+Message::Message(uint32_t aSeq, uint8_t *apData, size_t aLen) :
+    m_seq(aSeq)
+    , m_len(aLen)
+{
+    m_data = Buffer(aLen);
+    std::copy(apData, apData+aLen, m_data.GetWriteData());
+}
+
+Message::~Message()
+{
+    
+}
+
+Message::Message(Buffer::Reader& aReader) :
+    m_seq(0)
+    , m_len(SIZE_MAX)
+{
+    aReader.ReadBytes((uint8_t *) &m_seq, sizeof(m_seq));
+    aReader.ReadBytes((uint8_t *)&m_len, sizeof(m_len));
+
+    if (m_len <= aReader.GetSize() - aReader.GetBytePosition())
+    {
+        m_data = Buffer(m_len);
+        aReader.ReadBytes(m_data.GetWriteData(), m_len);
+    }
+    else
+    {
+        m_data = Buffer();
+    }
+}
+
+uint32_t Message::GetSeq() const noexcept
+{
+    return m_seq;
+}
+
+Buffer::Reader Message::GetData() noexcept
+{
+    return Buffer::Reader(&m_data);
+}
+
+bool Message::Write(Buffer::Writer& aWriter) const noexcept
+{
+    return aWriter.WriteBytes((uint8_t *) &m_seq, sizeof(m_seq))
+    && aWriter.WriteBytes((uint8_t *)&m_len, sizeof(m_len))
+    && aWriter.WriteBytes(m_data.GetData(), m_len);
+}
+

--- a/Code/protocol/src/Message.cpp
+++ b/Code/protocol/src/Message.cpp
@@ -1,34 +1,84 @@
 #include "Message.h"
 
-Message::Message(uint32_t aSeq, uint8_t *apData, size_t aLen) :
-    m_seq(aSeq)
+#include <algorithm>
+
+Message::Message(uint32_t aSeq, uint8_t *apData, size_t aLen) noexcept
+    : m_slices({std::move(Message::Slice(apData, aLen))})
     , m_len(aLen)
+    , m_seq(aSeq)
 {
-    m_data = Buffer(aLen);
-    std::copy(apData, apData+aLen, m_data.GetWriteData());
+
 }
 
-Message::~Message()
+Message::Message(Buffer::Reader& aReader) noexcept
+    : m_slices()
+    , m_len(0)
+    , m_seq(0)
+{
+    aReader.ReadBytes((uint8_t *)&m_seq, sizeof(m_seq));
+
+    if (aReader.ReadBits(m_len, Message::MessageLenBits) && m_len <= Message::MaxMessageSize)
+    {
+        m_slices.push_front(Slice(aReader, m_len));
+        
+        Slice& slice = m_slices.front();
+        
+        if (slice.m_empty)
+        {
+            // Could not read slice for some reason. This message should be invalid
+            m_len = 0;
+        }
+        else
+        {
+            if (slice.m_offset > 0)
+            {
+                // add empty slice before
+                m_slices.push_front(Slice((size_t) 0, slice.m_offset));
+            }
+
+            if (slice.m_offset + slice.m_len < m_len)
+            {
+                // add empty slice after
+                m_slices.push_back(Slice(slice.m_offset + slice.m_len, m_len - slice.m_offset - slice.m_len));
+            }
+        }
+    }
+}
+
+Message::Message(Message && aRhs) noexcept
+{
+    this->operator=(std::move(aRhs));
+}
+
+Message::Message(const Message & acRhs) noexcept
+{
+    this->operator=(acRhs);
+}
+
+Message::~Message() noexcept
 {
     
 }
 
-Message::Message(Buffer::Reader& aReader) :
-    m_seq(0)
-    , m_len(SIZE_MAX)
+Message & Message::operator=(Message && aRhs) noexcept
 {
-    aReader.ReadBytes((uint8_t *) &m_seq, sizeof(m_seq));
-    aReader.ReadBytes((uint8_t *)&m_len, sizeof(m_len));
+    this->m_seq = aRhs.m_seq;
+    this->m_len = aRhs.m_len;
+    this->m_slices = std::move(aRhs.m_slices);
 
-    if (m_len <= aReader.GetSize() - aReader.GetBytePosition())
-    {
-        m_data = Buffer(m_len);
-        aReader.ReadBytes(m_data.GetWriteData(), m_len);
-    }
-    else
-    {
-        m_data = Buffer();
-    }
+    aRhs.m_seq = 0;
+    aRhs.m_len = 0;
+
+    return *this;
+}
+
+Message & Message::operator=(const Message & acRhs) noexcept
+{
+    this->m_seq = acRhs.m_seq;
+    this->m_len = acRhs.m_len;
+    this->m_slices = acRhs.m_slices;
+
+    return *this;
 }
 
 uint32_t Message::GetSeq() const noexcept
@@ -36,15 +86,115 @@ uint32_t Message::GetSeq() const noexcept
     return m_seq;
 }
 
-Buffer::Reader Message::GetData() noexcept
+size_t Message::GetLen() const noexcept
 {
-    return Buffer::Reader(&m_data);
+    return m_len;
 }
 
-bool Message::Write(Buffer::Writer& aWriter) const noexcept
+// Returns true if this message is ready (has only one slice)
+bool Message::IsComplete() const noexcept
 {
-    return aWriter.WriteBytes((uint8_t *) &m_seq, sizeof(m_seq))
-    && aWriter.WriteBytes((uint8_t *)&m_len, sizeof(m_len))
-    && aWriter.WriteBytes(m_data.GetData(), m_len);
+    return IsValid() && m_slices.size() == 1;
 }
 
+bool Message::IsValid() const noexcept
+{
+    return m_len > 0 && m_slices.size() > 0;
+}
+
+// Do not call this if IsComplete() returns false or face undefined behavior
+Buffer::Reader Message::GetData() const noexcept
+{
+    return Buffer::Reader((Buffer *)&m_slices.front().m_data);
+}
+
+// Returns the number of bytes of real data (not headers) written
+size_t Message::Write(Buffer::Writer& aWriter, size_t aOffset) const noexcept
+{
+    if (!IsComplete())
+        return 0;   // this should never happen(tm)
+
+    size_t headerBytes = sizeof(m_seq) + (2*Message::MessageLenBits + 7) / 8;
+    size_t availableBytes = aWriter.GetSize() - aWriter.GetBytePosition();
+
+    if (availableBytes <= headerBytes)
+    {
+        // Don't even try to write a slice because it won't fit
+        return 0;
+    }
+
+
+    aWriter.WriteBytes((uint8_t *)&m_seq, sizeof(m_seq));
+    aWriter.WriteBits(m_len, Message::MessageLenBits);
+    aWriter.WriteBits(aOffset, Message::MessageLenBits);
+
+    availableBytes = aWriter.GetSize() - aWriter.GetBytePosition();
+    size_t bytesToWrite = std::min(availableBytes, m_len - aOffset);
+    aWriter.WriteBytes(m_slices.front().m_data.GetData()+aOffset, bytesToWrite);
+    
+    return bytesToWrite;
+}
+
+Message::Slice::Slice(size_t aOffset, size_t aLen) noexcept
+    : m_offset(aOffset)
+    , m_len(aLen)
+    , m_empty(true)
+{
+
+}
+
+Message::Slice::Slice(uint8_t *apData, size_t aLen) noexcept
+    : m_offset(0)
+    , m_len(aLen)
+    , m_empty(false)
+{
+    m_data = Buffer(aLen);
+    std::copy(apData, apData + aLen, m_data.GetWriteData());
+}
+
+Message::Slice::Slice(Buffer::Reader& aReader, size_t aMessageLength) noexcept
+    : m_offset(0)
+    , m_len(0)
+    , m_empty(true)
+{
+    if (aReader.ReadBits(m_offset, Message::MessageLenBits) && m_offset < aMessageLength)
+    {
+        m_len = std::min(aReader.GetSize() - aReader.GetBytePosition(), aMessageLength - m_offset);
+        m_data = Buffer(m_len);
+        m_empty = !aReader.ReadBytes(m_data.GetWriteData(), m_len);
+    }
+}
+
+Message::Slice::Slice(Slice && aRhs) noexcept
+{
+    this->operator=(std::move(aRhs));
+}
+
+Message::Slice::Slice(const Slice & acRhs) noexcept
+{
+    this->operator=(acRhs);
+}
+
+Message::Slice& Message::Slice::operator=(Slice && aRhs) noexcept
+{
+    this->m_offset = aRhs.m_offset;
+    this->m_len = aRhs.m_len;
+    this->m_empty = aRhs.m_empty;
+    this->m_data = std::move(aRhs.m_data);
+
+    aRhs.m_offset = 0;
+    aRhs.m_len = 0;
+    aRhs.m_empty = true;
+
+    return *this;
+}
+
+Message::Slice& Message::Slice::operator=(const Slice & acRhs) noexcept
+{
+    this->m_offset = acRhs.m_offset;
+    this->m_len = acRhs.m_len;
+    this->m_empty = acRhs.m_empty;
+    this->m_data = acRhs.m_data;
+
+    return *this;
+}

--- a/Code/protocol/src/MessageReceiver.cpp
+++ b/Code/protocol/src/MessageReceiver.cpp
@@ -1,0 +1,68 @@
+#include "MessageReceiver.h"
+
+
+
+MessageReceiver::MessageReceiver() noexcept
+    : m_messageBuffer(MessageReceiver::MessageBufferSize, nullptr)
+{}
+
+
+MessageReceiver::~MessageReceiver() noexcept
+{
+    for (Message *pMessage : m_messageBuffer)
+    {
+        if (pMessage != nullptr)
+            GetAllocator()->Delete<Message>(pMessage);
+    }
+}
+
+Outcome<Message, MessageReceiver::Error> MessageReceiver::ReadMessage(Buffer::Reader &aReader) noexcept
+{
+    if (aReader.GetSize() - aReader.GetBytePosition() <= Message::HeaderBytes)
+    {
+        return MessageReceiver::Error::kNoMessage;
+    }
+
+    Message message(aReader);
+
+    if (!message.IsValid())
+        return MessageReceiver::Error::kNoMessage;
+
+    if (message.IsComplete())
+        return message;
+
+
+    size_t mPos = message.GetSeq() % MessageReceiver::MessageBufferSize;
+
+    if (m_messageBuffer[mPos] == nullptr)
+    {
+        m_messageBuffer[mPos] = GetAllocator()->New<Message>(std::move(message));
+        return *m_messageBuffer[mPos];
+    }
+
+    Message& oldMessage = *m_messageBuffer[mPos];
+
+    if (oldMessage.GetSeq() == message.GetSeq())
+    {
+        if (oldMessage.GetLen() != message.GetLen())
+            return MessageReceiver::Error::kLengthsMismatch;
+
+        if (oldMessage.IsComplete())
+            return oldMessage;
+
+        Message::Merge(oldMessage, message);
+        return oldMessage;
+    }
+    else
+    {
+        if (oldMessage.GetSeq() > message.GetSeq())
+            return MessageReceiver::Error::kOld;
+
+        // Buffer entry is stale, replace it
+        GetAllocator()->Delete<Message>(m_messageBuffer[mPos]);
+        m_messageBuffer[mPos] = GetAllocator()->New<Message>(std::move(message));
+        return *m_messageBuffer[mPos];
+    }
+
+    // return MessageReceiver::Error::kUndeterminedErrorBecauseIveMissedSomeCondition;
+}

--- a/Code/tests/src/network.cpp
+++ b/Code/tests/src/network.cpp
@@ -284,6 +284,7 @@ TEST_CASE("Networking", "[network]")
         clientv6.Bind();
         clientv4.Bind();
 
+        /*
         Socket::Packet packetv6{ serverEndpointv6, buffer };
         Socket::Packet packetv4{ serverEndpointv4, buffer };
 
@@ -299,6 +300,7 @@ TEST_CASE("Networking", "[network]")
         REQUIRE(clientv4.Send(packetv4));
 
         REQUIRE(server.Update(1) == 2);
+        */
     }
 }
 

--- a/Code/tests/src/network.cpp
+++ b/Code/tests/src/network.cpp
@@ -340,7 +340,7 @@ TEST_CASE("Server", "[network.server]")
             }
         }
 
-        size_t NumClients()
+        size_t GetNumClients() const
         {
             return m_clients.size();
         }
@@ -436,7 +436,7 @@ TEST_CASE("Server", "[network.server]")
             REQUIRE(server.Start(0));
             REQUIRE(server.GetPort() != 0);
             REQUIRE(server.Update(1) == 0);
-            REQUIRE(server.NumClients() == 0);
+            REQUIRE(server.GetNumClients() == 0);
             serverEndpoint.SetPort(server.GetPort());
         }
 
@@ -450,13 +450,13 @@ TEST_CASE("Server", "[network.server]")
             REQUIRE(client1.m_connected == false);
 
             REQUIRE(server.Update(1) == 1);
-            REQUIRE(server.NumClients() == 0);
+            REQUIRE(server.GetNumClients() == 0);
 
             REQUIRE(client1.Update(1) == 1);
             REQUIRE(client1.m_connected == true);
 
             REQUIRE(server.Update(1) == 1);
-            REQUIRE(server.NumClients() == 1);
+            REQUIRE(server.GetNumClients() == 1);
         }
 
         WHEN("Client 1 sends some packets")
@@ -489,17 +489,17 @@ TEST_CASE("Server", "[network.server]")
             REQUIRE(client1.m_connected == true);
             REQUIRE(client2.m_connected == false);
             REQUIRE(client2.m_connected == false);
-            REQUIRE(server.NumClients() == 1);
+            REQUIRE(server.GetNumClients() == 1);
             REQUIRE(client2.Update(1) == 0);
             REQUIRE(client3.Update(1) == 0);
             REQUIRE(server.Update(1) == 2);
-            REQUIRE(server.NumClients() == 1);
+            REQUIRE(server.GetNumClients() == 1);
             REQUIRE(client2.Update(1) == 1);
             REQUIRE(client3.Update(1) == 1);
             REQUIRE(client2.m_connected == true);
             REQUIRE(client3.m_connected == true);
             REQUIRE(server.Update(1) == 2);
-            REQUIRE(server.NumClients() == 3);
+            REQUIRE(server.GetNumClients() == 3);
         }
 
         WHEN("Clients exchange packets")
@@ -523,7 +523,7 @@ TEST_CASE("Server", "[network.server]")
 
         WHEN("Clients 1 and 2 disconnect")
         {
-            REQUIRE(server.NumClients() == 3);
+            REQUIRE(server.GetNumClients() == 3);
             REQUIRE(client1.m_connected == true);
             REQUIRE(client2.m_connected == true);
             
@@ -537,15 +537,15 @@ TEST_CASE("Server", "[network.server]")
             REQUIRE(client2.m_connected == false);
 
             REQUIRE(server.Update(1) == 2);
-            REQUIRE(server.NumClients() == 1);
+            REQUIRE(server.GetNumClients() == 1);
         }
 
         WHEN("Client 3 times out")
         {
-            REQUIRE(server.NumClients() == 1);
+            REQUIRE(server.GetNumClients() == 1);
             REQUIRE(client3.m_connected == true);
             REQUIRE(server.Update(60 * 1000) == 0);
-            REQUIRE(server.NumClients() == 0);
+            REQUIRE(server.GetNumClients() == 0);
         }
     }
 }

--- a/Code/tests/src/protocol.cpp
+++ b/Code/tests/src/protocol.cpp
@@ -112,7 +112,8 @@ TEST_CASE("Message", "[protocol.message]")
         // now we have a really mean test case
 
         MessageReceiver messageReceiver;
-        Message& receivedMessage = Message();
+        Message emptyMessage = Message();
+        Message& receivedMessage = emptyMessage;
 
         for (size_t offset : randomOffsets)
         {

--- a/Code/tests/src/protocol.cpp
+++ b/Code/tests/src/protocol.cpp
@@ -61,10 +61,12 @@ TEST_CASE("Message", "[protocol.message]")
     GIVEN("A simple Message")
     {
         Message message(24, (uint8_t *) data.data(), data.length());
+        REQUIRE(message.IsComplete());
         REQUIRE(message.GetSeq() == 24);
+        REQUIRE(message.GetLen() == data.length());
 
         Buffer::Reader reader = message.GetData();
-        REQUIRE(reader.GetSize() == data.length());
+        REQUIRE(reader.GetSize() == message.GetLen());
 
         Buffer buffer(data.length());
         REQUIRE(reader.ReadBytes(buffer.GetWriteData(), data.length()) == true);
@@ -78,9 +80,10 @@ TEST_CASE("Message", "[protocol.message]")
         Buffer::Writer writer(&buffer);
         Buffer::Reader reader(&buffer);
 
-        REQUIRE(senderMessage.Write(writer) == true);
+        REQUIRE(senderMessage.Write(writer) == data.length());
         
         Message receiverMessage(reader);
+        REQUIRE(receiverMessage.IsComplete());
         REQUIRE(receiverMessage.GetSeq() == senderMessage.GetSeq());
         
         reader = receiverMessage.GetData();


### PR DESCRIPTION
Hello again! I've added some listeners for `Server`, created a convenient `Client` class and, more importantly, made `Connection` handle all the negotiation with ideas from [gafferongames](https://web.archive.org/web/20181107181442/https://gafferongames.com/post/client_server_connection/):
1. Client sends a negotiation packet to server, with its public key and a randomly generated challenge code.
2. Server replies with its negotiation code, public key and another random challenge code.
3. Since the IV are now initialized, Client sends a confirmation packet with encrypted `client_challenge^server_challenge`. From this point, the client considers itself connected and stops sending negotiation packets, although it keeps replying with a confirmation for every time it gets a negotiation packet from the server, as the older confirmation may have been lost.
4. The server decrypts and validates the challenge code and also moves to connected state, so the negotiation is over for both.

Apart from the tests, you can check how the new model is supposed to work with [my example client and server programs](https://gist.github.com/dgalaktionov/4f5602082d9f9168fae2d46b18943919). I've also used [clumsy](https://jagt.github.io/clumsy/) (what a wonderful tool) to ensure that the connection is robust and eventually establishes under unstable networks with lost packets, unless the situation is very bad and the connection times out.

I understand this is a rather large PR and may take some time to review, but it would feel incomplete if I made it any smaller. Nevertheless, I'd like to have you input on some of my concerns when you have the time:
- Do you see any problems with the negotiation method? Am I correct in my understanding that ChaCha20 is considered secure against known plaintext attacks?
- A lot of the code looks the same in `Client` and `Server`. I could include the listeners in ICommunication and let `Connection` grow a bit larger by handing most of the logic from `Client::ProcessPacket` and `Server::ProcessPacket`. What do you think?
- As it is now, memory is allocated before every packet sent, and freed after. I'm not sure how much performance overhead that implies. I guess someone is working on #1 so we could find out soon...